### PR TITLE
Afegeix el namespace a les crides de les funcions de paquets importats

### DIFF
--- a/R/get_all_schools.R
+++ b/R/get_all_schools.R
@@ -1,6 +1,5 @@
 library(tidyverse)
-library(osmdata)
-library(sf)
+
 #' @title get_all_schools
 #' @description get all schools registered in openstreetmapand the Catalan government from a municipality or comarca in Cataloniamat
 #' @param place character. name of the place for which to get schools - municipality or comarca
@@ -8,14 +7,14 @@ library(sf)
 #' @returns A tibble with all schools or a list with said tibble and a map.
 #' @export
 get_all_schools <- function(place, plot = TRUE){
-  osm_schools <- catosmamenities::get_osm_schools(place, is_sf = TRUE)
-  gencat_schools <- catosmamenities::get_gencat_schools(place, is_sf = TRUE)
+  osm_schools <- get_osm_schools(place, is_sf = TRUE)
+  gencat_schools <- get_gencat_schools(place, is_sf = TRUE)
   osm_schools_df <- osm_schools |> 
-    st_drop_geometry()
+    sf::st_drop_geometry()
   colnames(osm_schools_df) <- sapply(colnames(osm_schools_df), 
                                      \(x) ifelse(x == "ref", x, paste0("osm_",x)))
   gencat_schools_df <- gencat_schools |> 
-    st_drop_geometry()
+    sf::st_drop_geometry()
   colnames(gencat_schools_df) <- sapply(colnames(gencat_schools_df), 
                                      \(x) ifelse(x %in% c("ref", "source:date"), x, paste0("gencat_",x)))
   all_schools <- full_join(gencat_schools_df, osm_schools_df, by = "ref") |> 
@@ -33,16 +32,15 @@ get_all_schools <- function(place, plot = TRUE){
                     "osm_contact:phone", "gencat_contact:phone", "osm_website", "gencat_website",
                     "osm_wheelchair", "osm_wikidata")))
   if(plot == TRUE){
-    tmap_mode("view")
-    plot <- tm_shape(mutate(osm_schools, source = "OSM")) + 
-      tm_symbols(shape = 16,
+    tmap::tmap_mode("view")
+    plot <- tmap::tm_shape(mutate(osm_schools, source = "OSM")) + 
+      tmap::tm_symbols(shape = 16,
                  col = "blue") + 
-      tm_shape(mutate(gencat_schools, source = "GENCAT")) + 
-      tm_symbols(shape = 18,
+      tmap::tm_shape(mutate(gencat_schools, source = "GENCAT")) + 
+      tmap::tm_symbols(shape = 18,
                  col = "red")
     return(list(plot = plot, df = all_schools))
   }
-  else return(all_schools)
-
-    
+  else
+    return(all_schools)
 }

--- a/R/get_filter_bbox.R
+++ b/R/get_filter_bbox.R
@@ -1,7 +1,4 @@
 library(tidyverse)
-library(osmdata)
-library(sf)
-
 
 #' @title get_filter_bbox
 #' @description get a bbox for filtering rest apis
@@ -14,21 +11,21 @@ get_filter_bbox <- function(place, transform = FALSE, end_crs = "EPSG:25831"){
   place <- paste0(place, ", Spain")
   if(transform == FALSE){
     
-    opq <- opq(place)
+    opq <- osmdata::opq(place)
     bbox <- opq$bbox
     bbox <- as.vector(sapply(str_split(bbox,","), as.numeric))
     return(bbox)
   }
   else{
-    bbox <- getbb(place, format_out = "sf_polygon")
+    bbox <- osmdata::getbb(place, format_out = "sf_polygon")
     if(!is.null(bbox$multipolygon)) {
-      bbox <- st_transform(bbox$multipolygon, crs = end_crs)
-      }
-    else if(nrow(bbox) == 1){
-      bbox <- st_transform(bbox, crs = end_crs)
-      }
-    else {bbox <- st_transform(bbox[1,], crs = end_crs)}
-    bbox <- st_bbox(bbox)
+      bbox <- sf::st_transform(bbox$multipolygon, crs = end_crs)
+    } else if(nrow(bbox) == 1){
+      bbox <- sf::st_transform(bbox, crs = end_crs)
+    } else {
+      bbox <- sf::st_transform(bbox[1,], crs = end_crs)
+    }
+    bbox <- sf::st_bbox(bbox)
     bbox <- unname(bbox)
     bbox <- c(bbox[2], bbox[1], bbox[4], bbox[3])
     return(bbox)

--- a/R/get_osm_schools.R
+++ b/R/get_osm_schools.R
@@ -1,6 +1,5 @@
 library(tidyverse)
-library(osmdata)
-library(sf)
+
 #' @title get_osm_schools
 #' @description get all schools registered in openstreetmap from a municipality or comarca in Catalonia in either sf or table format
 #' @param place character. name of the place for which to get schools - municipality or comarca
@@ -8,14 +7,14 @@ library(sf)
 #' @returns A sf or tibble with all schools in the desired place.
 #' @export
 get_osm_schools <- function(place, is_sf = TRUE){
-  schools <- add_osm_features(opq = opq(paste0(place, ", Spain"), osm_types="nwr"), 
+  schools <- osmdata::add_osm_features(opq = osmdata::opq(paste0(place, ", Spain"), osm_types="nwr"), 
                               features = list("amenity" = "school",
                                   "amenity" = "kindergarten",
                                   "amenity" = "music_school",
                                   "amenity" = "dancing_school",
                                   "amenity" = "language_school"))
   if(is_sf == TRUE) {
-    schools <- osmdata_sf(schools)
+    schools <- osmdata::osmdata_sf(schools)
     schools_p <- schools$osm_points
     schools_pol <- schools$osm_polygons
     schools_mp <- schools$osm_multipolygons
@@ -86,12 +85,11 @@ get_osm_schools <- function(place, is_sf = TRUE){
                                      "contact:fax", "contact:phone", "website",
                                      "wheelchair", "wikidata", "name:etimology:wikidata")))
       schools <- bind_rows(schools_p, schools_mp, schools_pol) |> 
-        mutate(geometry = st_centroid(geometry))
+        mutate(geometry = sf::st_centroid(geometry))
     }
   }  
   else {
-    schools <- 
-    osmdata_data_frame(schools)
+    schools <- osmdata::osmdata_data_frame(schools)
     schools <- select(schools,
                       any_of(c("name", "name:ca", "ref", 
                                "school", "isced:level", "min_age", "max_age",


### PR DESCRIPTION
Queda pendent arreglar les funcions de tidyverse. No sóc d'aquesta escola, però em sembla que es poden importar els paquets o funcions al `NAMESPACE` si no vols afegir el prefix a cada crida. Amb roxygen es pot afegir el camp `@import` o `@importFrom` a les funcions que usin tidyvers perquè les afegeixi automàticament.

La idea és que no quedin errors ni warnings a `R CMD check`. Segurament me n'he descuidat alguns casos